### PR TITLE
Fixed SetKeepAlive for Linux.

### DIFF
--- a/Firebase.Cloud.Messaging/FcmConnection.cs
+++ b/Firebase.Cloud.Messaging/FcmConnection.cs
@@ -27,10 +27,12 @@ namespace Firebase.Cloud.Messaging
         public async Task ConnectAsync()
         {
             client = new TcpClient(host, port);
-            SetKeepAlive(client.Client, 60 * 1000, 60 * 1000); //TODO: test keep alive
+            client.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+            client.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveInterval, 60);
+            client.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, 60);
 
             sslStream = new SslStream(client.GetStream(), false, new RemoteCertificateValidationCallback(ValidateServerCertificate), null);
-            await sslStream.AuthenticateAsClientAsync(host, null, SslProtocols.Tls, false).ConfigureAwait(false);
+            await sslStream.AuthenticateAsClientAsync(host, null, SslProtocols.Tls13, false).ConfigureAwait(false);
         }
 
         public async Task SendAsync(byte[] data, CancellationToken cancellationToken)
@@ -72,46 +74,15 @@ namespace Firebase.Cloud.Messaging
                     }
                 }
             }
-            catch(SocketException)
+            catch (SocketException)
             {
-                
+
             }
-            catch(OperationCanceledException)
+            catch (OperationCanceledException)
             {
 
             }
         }
-
-        /// <summary>
-        ///     Sets the Keep-Alive values for the current tcp connection
-        /// </summary>
-        /// <param name="socket">Current socket instance</param>
-        /// <param name="keepAliveInterval">Specifies how often TCP repeats keep-alive transmissions when no response is received. TCP sends keep-alive transmissions to verify that idle connections are still active. This prevents TCP from inadvertently disconnecting active lines.</param>
-        /// <param name="keepAliveTime">Specifies how often TCP sends keep-alive transmissions. TCP sends keep-alive transmissions to verify that an idle connection is still active. This entry is used when the remote system is responding to TCP. Otherwise, the interval between transmissions is determined by the value of the keepAliveInterval entry.</param>
-        public static void SetKeepAlive(Socket socket, uint keepAliveInterval, uint keepAliveTime)
-        {
-            var keepAlive = new TcpKeepAlive
-            {
-                onoff = 1,
-                keepaliveinterval = keepAliveInterval,
-                keepalivetime = keepAliveTime
-            };
-            int size = Marshal.SizeOf(keepAlive);
-            IntPtr keepAlivePtr = Marshal.AllocHGlobal(size);
-            Marshal.StructureToPtr(keepAlive, keepAlivePtr, true);
-            var buffer = new byte[size];
-            Marshal.Copy(keepAlivePtr, buffer, 0, size);
-            Marshal.FreeHGlobal(keepAlivePtr);
-            socket.IOControl(IOControlCode.KeepAliveValues, buffer, null);
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct TcpKeepAlive
-        {
-            internal uint onoff;
-            internal uint keepalivetime;
-            internal uint keepaliveinterval;
-        };
 
         private static bool ValidateServerCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
         {

--- a/Firebase.Cloud.Messaging/Firebase.Cloud.Messaging.csproj
+++ b/Firebase.Cloud.Messaging/Firebase.Cloud.Messaging.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixed SetKeepAlive for Linux.
Now it does not throw PlatformNotSupportedException.
Changed Tls version to 1.3 because Tls 1.0 is deprecated and OpenSSL 1.1.1. doesn't support it.
Tested on Ubuntu 21.04 with OpenSSL 1.1.1j