### PR TITLE
Fixed Tls version for Windows 10 and Windows 7.

### DIFF
--- a/Firebase.Cloud.Messaging/FcmConnection.cs
+++ b/Firebase.Cloud.Messaging/FcmConnection.cs
@@ -32,7 +32,7 @@ namespace Firebase.Cloud.Messaging
             client.Client.SetSocketOption(SocketOptionLevel.Tcp, SocketOptionName.TcpKeepAliveTime, 60);
 
             sslStream = new SslStream(client.GetStream(), false, new RemoteCertificateValidationCallback(ValidateServerCertificate), null);
-            await sslStream.AuthenticateAsClientAsync(host, null, SslProtocols.Tls13, false).ConfigureAwait(false);
+            await sslStream.AuthenticateAsClientAsync(host, null, SslProtocols.Tls13 | SslProtocols.Tls12, false).ConfigureAwait(false);
         }
 
         public async Task SendAsync(byte[] data, CancellationToken cancellationToken)

--- a/Firebase.Cloud.Messaging/FcmConnection.cs
+++ b/Firebase.Cloud.Messaging/FcmConnection.cs
@@ -68,7 +68,7 @@ namespace Firebase.Cloud.Messaging
                     }
 
                     // it seems that if the underlying socket is disconnected no exception is thrown
-                    if (client.Connected == false)
+                    if (!client.Connected || bytesRead == 0)
                     {
                         throw new SocketException(1);
                     }

--- a/Firebase.Cloud.Messaging/FcmListener.cs
+++ b/Firebase.Cloud.Messaging/FcmListener.cs
@@ -316,7 +316,8 @@ namespace Firebase.Cloud.Messaging
                 byte[] unreadBytes = new byte[unreadBytesCount];
 
                 dataStream.Read(unreadBytes, 0, unreadBytes.Length);
-                dataStream = new MemoryStream(unreadBytes);
+                dataStream = new MemoryStream(unreadBytes.Length);
+                dataStream.Write(unreadBytes, 0, unreadBytes.Length);
             }
             else
             {


### PR DESCRIPTION
Fixed issue with tls 1.3 not supported by Windows 10 and Windows 7.
It should now work on both Windows and Linux.
This allows SslStream to choose supported Tls version.
```csharp
SslProtocols.Tls13 | SslProtocols.Tls12
```
Probably it could be like this:
```csharp
SslProtocols.Tls13 | SslProtocols.Tls12 | SslProtocols.Tls11| SslProtocols.Tls
```
Also fixed for System.NotSupportedException (Memory stream is not expandable)